### PR TITLE
Feature: Add MoodTrackerTool and refactor JournalStore with shared DB engine

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,36 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyInterpreterInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="21">
+            <item index="0" class="java.lang.String" itemvalue="notebook_shim" />
+            <item index="1" class="java.lang.String" itemvalue="jupyter_server" />
+            <item index="2" class="java.lang.String" itemvalue="jupyterlab_widgets" />
+            <item index="3" class="java.lang.String" itemvalue="jupyterlab_pygments" />
+            <item index="4" class="java.lang.String" itemvalue="jupyter_client" />
+            <item index="5" class="java.lang.String" itemvalue="typing_extensions" />
+            <item index="6" class="java.lang.String" itemvalue="jupyter_server_terminals" />
+            <item index="7" class="java.lang.String" itemvalue="prometheus_client" />
+            <item index="8" class="java.lang.String" itemvalue="jupyter_core" />
+            <item index="9" class="java.lang.String" itemvalue="jupyterlab_server" />
+            <item index="10" class="java.lang.String" itemvalue="pandas" />
+            <item index="11" class="java.lang.String" itemvalue="scipy" />
+            <item index="12" class="java.lang.String" itemvalue="matplotlib" />
+            <item index="13" class="java.lang.String" itemvalue="sentence_transformers" />
+            <item index="14" class="java.lang.String" itemvalue="deep_translator" />
+            <item index="15" class="java.lang.String" itemvalue="controller" />
+            <item index="16" class="java.lang.String" itemvalue="paho_mqtt" />
+            <item index="17" class="java.lang.String" itemvalue="scikit_learn" />
+            <item index="18" class="java.lang.String" itemvalue="huggingface_hub" />
+            <item index="19" class="java.lang.String" itemvalue="duckduckgo-search" />
+            <item index="20" class="java.lang.String" itemvalue="langchain_community" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/jupyter-settings.xml
+++ b/.idea/jupyter-settings.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JupyterPersistentConnectionParameters">
+    <option name="moduleParameters">
+      <map>
+        <entry key="$USER_HOME$/Coliee/COLIEE2022_HONto/.idea/COLIEE2022_HONto.iml">
+          <value>
+            <JupyterConnectionParameters>
+              <option name="managed" value="true" />
+              <option name="port" value="8886" />
+            </JupyterConnectionParameters>
+          </value>
+        </entry>
+        <entry key="$USER_HOME$/thesis/knowledge_graph/.idea/knowledge_graph.iml">
+          <value>
+            <JupyterConnectionParameters>
+              <option name="managed" value="true" />
+              <option name="sdkHomePath" value="$USER_HOME$/thesis/knowledge_graph_rahulnyk/venv/bin/python" />
+            </JupyterConnectionParameters>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/mindmate_proj.iml
+++ b/.idea/mindmate_proj.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.11 (mindmate_proj)" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (mindmate_proj)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/mindmate_proj.iml" filepath="$PROJECT_DIR$/.idea/mindmate_proj.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/db/engine.py
+++ b/app/db/engine.py
@@ -1,0 +1,7 @@
+import os
+from dotenv import load_dotenv
+from sqlalchemy.ext.asyncio import create_async_engine
+
+load_dotenv()
+DATABASE_URL = os.getenv("DATABASE_URL")
+engine = create_async_engine(DATABASE_URL, echo=False)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,0 +1,23 @@
+
+from sqlalchemy import Table, Column, Integer, String, Text, TIMESTAMP, MetaData
+
+metadata = MetaData()
+
+journal_entries = Table(
+    "journal_entries",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("user_id", String, default="anonymous"),
+    Column("content", Text, nullable=False),
+    Column("created_at", TIMESTAMP)
+)
+
+mood_logs = Table(
+    "mood_logs",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("user_id", String, default="anonymous"),
+    Column("message", Text, nullable=False),
+    Column("mood_label", String),
+    Column("timestamp", TIMESTAMP)
+)

--- a/app/db/view_records.py
+++ b/app/db/view_records.py
@@ -1,9 +1,11 @@
 import os
 import asyncio
 from dotenv import load_dotenv
-from sqlalchemy import Table, Column, Integer, String, Text, TIMESTAMP, MetaData
+from sqlalchemy import (
+    Table, Column, Integer, String, Text, TIMESTAMP, MetaData, UUID, desc, select
+)
 from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.sql import select
+from app.db.models import journal_entries, mood_logs, metadata
 
 # Load .env for DB URL
 load_dotenv()
@@ -12,26 +14,36 @@ DATABASE_URL = os.getenv("DATABASE_URL")
 # Async engine
 engine = create_async_engine(DATABASE_URL, echo=True)
 
-# Define metadata and table
-metadata = MetaData()
-
-journal_entries = Table(
-    "journal_entries",
-    metadata,
-    Column("id", Integer, primary_key=True),
-    Column("user_id", String),
-    Column("content", Text, nullable=False),
-    Column("created_at", TIMESTAMP)
-)
-
-# Function to fetch all rows
-async def show_all_entries():
+# Fetch sample records from both tables
+async def fetch_sample_records(limit: int = 5) -> dict:
     async with engine.begin() as conn:
-        result = await conn.execute(select(journal_entries))
-        rows = result.mappings().all()
-        for row in rows:
-            print(dict(row))
+        # Get recent journal entries
+        journal_result = await conn.execute(
+            select(journal_entries).order_by(desc(journal_entries.c.created_at)).limit(limit)
+        )
+        journals = [dict(row) for row in journal_result.mappings().all()]
 
-# Run test
+        # Get recent mood logs
+        mood_result = await conn.execute(
+            select(mood_logs).order_by(desc(mood_logs.c.timestamp)).limit(limit)
+        )
+        moods = [dict(row) for row in mood_result.mappings().all()]
+
+        return {
+            "journals": journals,
+            "mood_logs": moods
+        }
+
+# CLI testing
 if __name__ == "__main__":
-    asyncio.run(show_all_entries())
+    async def main():
+        records = await fetch_sample_records()
+        print("Latest Journal Entries:")
+        for entry in records["journals"]:
+            print(entry)
+
+        print(" Latest Mood Logs:")
+        for mood in records["mood_logs"]:
+            print(mood)
+
+    asyncio.run(main())

--- a/app/langraph_runner.py
+++ b/app/langraph_runner.py
@@ -6,6 +6,8 @@ from dotenv import load_dotenv
 from app.tools.journaling.journalling_prompt_generator import generate_prompt
 from app.tools.journaling.journal_store import save_journal_entry
 from app.tools.journaling.prompt_utils import classify_journal_input
+from app.tools.selfcare.mood_tracker import log_mood, classify_mood
+from app.tools.selfcare.selcare_input_classifier import classify_selfcare_input
 
 # Load environment variables
 load_dotenv()
@@ -43,7 +45,22 @@ def route(state: State) -> str:
 
 # SelfCare agent node Stub
 async def selfcare_node(state: State) -> State:
-    response = f"[SelfCareAgent] You said: {state.input}. Here's a grounding tip: Take a deep breath and count to 4."
+    user_input = state.input
+    tool_class = await classify_selfcare_input(user_input)
+
+    if tool_class == "mood":
+        mood_label = await classify_mood(user_input)
+        await log_mood(user_input, mood_label)
+        response = f"[SelfCareAgent • MoodTracker] Mood logged as '{mood_label}'. You're not alone — thank you for checking in."
+
+    elif tool_class == "reminder":
+        # Stub: Reminder tool coming soon
+        response = "[SelfCareAgent • Reminder] This feature is not available yet. Stay tuned!"
+
+    else:  # tool_class == "advice"
+        # Stub: RAGTool advice coming soon
+        response = "[SelfCareAgent • Advice] This feature is under development. Thanks for your patience!"
+
     return state.model_copy(update={"response": response})
 
 # Journaling agent node Stub

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,9 @@
 from fastapi import FastAPI, Request
+
+from app.db.setup_db import reset_db
 from app.langraph_runner import app_flow
+
+from app.db.view_records import fetch_sample_records
 
 app = FastAPI()
 
@@ -12,3 +16,11 @@ async def chat(request: Request):
     result = await app_flow.ainvoke({"input": user_input})
 
     return {"response": result.get("response")}
+
+@app.get("/get_all_sample_records")
+async def get_all_sample_records():
+    return await fetch_sample_records(limit=5)
+
+@app.get("/reset_state")
+async def reset_state():
+    return await reset_db()

--- a/app/tools/journaling/journal_store.py
+++ b/app/tools/journaling/journal_store.py
@@ -1,31 +1,14 @@
-import os
 from datetime import datetime
-from dotenv import load_dotenv
-from sqlalchemy import Table, Column, Integer, Text, String, MetaData, TIMESTAMP
-from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.sql import insert
+from sqlalchemy import insert
 
-# Load .env
-load_dotenv()
-DATABASE_URL = os.getenv("DATABASE_URL")
-
-# Async DB engine
-engine = create_async_engine(DATABASE_URL)
-
-# SQLAlchemy Table definition
-metadata = MetaData()
-
-journal_entries = Table(
-    "journal_entries",
-    metadata,
-    Column("id", Integer, primary_key=True),
-    Column("user_id", String, default="anonymous"),
-    Column("content", Text, nullable=False),
-    Column("created_at", TIMESTAMP, default=datetime.utcnow),
-)
+from app.db.engine import engine
+from app.db.models import journal_entries
 
 # Tool: save a journal entry
 async def save_journal_entry(content: str, user_id: str = "anonymous"):
+    """
+    Inserts a journal entry into the journal_entries table.
+    """
     async with engine.begin() as conn:
         stmt = insert(journal_entries).values(
             user_id=user_id,

--- a/app/tools/selfcare/mood_tracker.py
+++ b/app/tools/selfcare/mood_tracker.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from openai import AsyncOpenAI
+from sqlalchemy import insert
+from dotenv import load_dotenv
+
+from app.db.models import mood_logs
+from app.db.engine import engine
+
+# Load env variables if not already loaded
+load_dotenv()
+
+# OpenAI client
+client = AsyncOpenAI()
+
+# Classify mood using LLM
+async def classify_mood(user_input: str) -> str:
+    """
+    Uses GPT to classify the user's mood in one word (e.g., happy, sad, anxious).
+    """
+    system_prompt = (
+        "Classify the user's mood in ONE word based on what they wrote. "
+        "Examples: happy, sad, tired, anxious, overwhelmed, calm. "
+        "Only return the word. Do not explain."
+    )
+
+    response = await client.chat.completions.create(
+        model="gpt-4.1-nano",
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_input}
+        ]
+    )
+
+    return response.choices[0].message.content.strip().lower()
+
+# Log mood to the DB
+async def log_mood(message: str, mood_label: str, user_id: str = "anonymous"):
+    """
+    Inserts a mood log into the `mood_logs` table.
+    """
+    async with engine.begin() as conn:  # BEGIN = transactional
+        stmt = insert(mood_logs).values(
+            user_id=user_id,
+            message=message,
+            mood_label=mood_label,
+            timestamp=datetime.utcnow()
+        )
+        await conn.execute(stmt)

--- a/app/tools/selfcare/selcare_input_classifier.py
+++ b/app/tools/selfcare/selcare_input_classifier.py
@@ -1,0 +1,29 @@
+from openai import AsyncOpenAI
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+client = AsyncOpenAI()
+
+async def classify_selfcare_input(user_input: str) -> str:
+    """
+    Classifies input as one of: 'mood', 'reminder', or 'advice'.
+    Only returns one word. Used by SelfCareAgent.
+    """
+    system_prompt = (
+        "Classify the user's input strictly as one of the following types:\n"
+        "- 'mood' → if they are expressing a feeling (e.g., 'I feel low')\n"
+        "- 'reminder' → if they ask for a recurring check-in or nudge\n"
+        "- 'advice' → if they ask a question about mental health or self-care\n\n"
+        "Only return one of these three words: 'mood', 'reminder', or 'advice'. Do not explain."
+    )
+
+    response = await client.chat.completions.create(
+        model="gpt-4.1-nano",
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_input}
+        ]
+    )
+
+    return response.choices[0].message.content.strip().lower()

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,0 +1,6 @@
+[bumpver]
+current_version = "2.0.0"
+version_pattern = "MAJOR.MINOR.PATCH"
+
+[bumpver.file_patterns]
+"pyproject.toml" = ['version = "{version}"']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.mindmate]
+version = "2.0.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ sqlalchemy # ORM for database interactions, useful for managing user data and ch
 asyncpg # Async PostgreSQL driver for SQLAlchemy, enabling efficient database operations
 
 greenlet
+
+bumpver  # Version management tool to handle versioning of your project


### PR DESCRIPTION
# Description:

This PR adds full support for mood tracking and refines the journaling functionality using a shared database layer. Both tools are integrated into the agent-based architecture using LangGraph, and rely on a consistent SQLAlchemy model and engine.

## Changes Included:

### JournalStoreTool:

File: app/tools/journaling/journal_store.py

Saves user journal entries using save_journal_entry(content: str, user_id: str = "anonymous")

Uses shared async SQLAlchemy engine and model definitions

Table: journal_entries (id, user_id, content, created_at)

### MoodTrackerTool:

File: app/tools/selfcare/mood_tracker.py

Uses GPT-4.1-nano to classify moods from free-text input

classify_mood(user_input: str) returns a one-word mood (e.g., sad, anxious)

Persists moods to the mood_logs table using log_mood(message: str, mood_label: str)

Table: mood_logs (id, user_id, message, mood_label, timestamp)

## Architecture:

Shared DB engine defined once in app/db/engine.py

Shared SQLAlchemy models moved to app/db/models.py

Both tools use the same async PostgreSQL connection via SQLAlchemy

## Testing:

Both mood and journal entries are confirmed to be inserted correctly

Sample API endpoint /get_all_sample_records shows latest logs

Outputs verified via LangGraph flow and direct API tests

## Example Response:

response: SelfCareAgent • MoodTracker Mood logged as 'anxious'. You're not alone — thank you for checking in.